### PR TITLE
Changed LED brightness minimum to 0

### DIFF
--- a/custom_components/lektrico_custom/number.py
+++ b/custom_components/lektrico_custom/number.py
@@ -79,7 +79,7 @@ NUMBERS: tuple[LektricoNumberEntityDescription, ...] = (
     LedBrightnessNumberEntityDescription(
         key="led_max_brightness",
         name="Led brightness",
-        native_min_value=10,
+        native_min_value=0,
         native_max_value=100,
         native_step=5,
         native_unit_of_measurement=PERCENTAGE,


### PR DESCRIPTION
The minimum brightess on the mobile Lektrico app is 0% which turns the LED's off. This change aligns the minimum with the mobile app.

Tested and confirmed working on 1P7K.

Since my charger is at the front of the property, I didn't want the bright LED's to be flashing out into the street, but I wanted to temporarily turn the LED's when my car returned home to remind me to plug it in.